### PR TITLE
Add manifest for Logging to Schedule

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "logging_to_schedule",
+  "name": "Logging to Schedule",
+  "version": "0.0.1",
+  "documentation": "https://github.com/koenbroumels/logging_to_schedule",
+  "dependencies": ["recorder"],
+  "requirements": [],
+  "codeowners": ["@koenbroumels"],
+  "iot_class": "local_polling"
+}


### PR DESCRIPTION
## Summary
- add manifest.json for Logging to Schedule integration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895183e775c8332a6b237ab405dbfc0